### PR TITLE
fix: Unrecognized adb binary in MacOS

### DIFF
--- a/backend/executor.go
+++ b/backend/executor.go
@@ -11,40 +11,64 @@ import (
 )
 
 func (a *App) getBinaryPath(name string) (string, error) {
+
 	platformDir := runtime.GOOS
-	extension := ""
-	if runtime.GOOS == "windows" {
-		extension = ".exe"
-	}
 
-	candidates := []string{
-		filepath.Join(".", "bin", platformDir, name+extension),
-	}
+	switch platformDir {
 
-	exePath, err := os.Executable()
-	if err != nil {
-		return "", err
-	}
-	installDir := filepath.Dir(exePath)
-	candidates = append(candidates, filepath.Join(installDir, "bin", platformDir, name+extension))
+	case "windows":
 
-	// Legacy fallback: allow flat bin layout so older installs still run.
-	candidates = append(candidates,
-		filepath.Join(".", "bin", name+extension),
-		filepath.Join(installDir, "bin", name+extension),
-	)
+		extension := ".exe"
 
-	for _, candidate := range candidates {
-		if candidate == "" {
-			continue
+		candidates := []string{
+			filepath.Join(".", "bin", platformDir, name+extension),
 		}
 
-		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
-			if filepath.IsAbs(candidate) {
-				return candidate, nil
+		exePath, err := os.Executable()
+		if err != nil {
+			return "", err
+		}
+		installDir := filepath.Dir(exePath)
+		candidates = append(candidates, filepath.Join(installDir, "bin", platformDir, name+extension))
+
+		// Legacy fallback: allow flat bin layout so older installs still run.
+		candidates = append(candidates,
+			filepath.Join(".", "bin", name+extension),
+			filepath.Join(installDir, "bin", name+extension),
+		)
+
+		for _, candidate := range candidates {
+			if candidate == "" {
+				continue
 			}
-			return filepath.Abs(candidate)
+
+			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+				if filepath.IsAbs(candidate) {
+					return candidate, nil
+				}
+				return filepath.Abs(candidate)
+			}
 		}
+
+	case "darwin":
+
+		// Fallback to system-installed binaries
+		// Check both Apple Silicon (/opt/homebrew/bin) and Intel (/usr/local/bin) Homebrew paths
+		homebrewPaths := []string{"/opt/homebrew/bin", "/usr/local/bin"}
+		for _, homebrewPath := range homebrewPaths {
+			binaryPath := filepath.Join(homebrewPath, name)
+			if info, err := os.Stat(binaryPath); err == nil && !info.IsDir() {
+				return binaryPath, nil
+			}
+		}
+
+		// Final fallback: use exec.LookPath to check system PATH
+		if path, err := exec.LookPath(name); err == nil {
+			return path, nil
+		}
+
+		return "", fmt.Errorf("binary '%s' not found. Please install adb via Homebrew or ensure it's in your PATH", name)
+
 	}
 
 	return "", fmt.Errorf("binary '%s' not found for platform '%s'", name, platformDir)


### PR DESCRIPTION
## Overview
Previously, when i tried to run this app in macOS. It throws following error:

```sh
failed to list files: binary 'adb' not found for platform 'darwin'. Output:
```

<img width="1136" height="908" alt="image" src="https://github.com/user-attachments/assets/f359fd38-b245-4d21-a29d-9b3d1a26e453" />


Basically this is happen because this `adb` binary is not handled in MacOS (Darwin). Therefor the executor is not recoginzing the `adb` (even though it is already installed in my machine)